### PR TITLE
Remove Gradle module metadata

### DIFF
--- a/gradle/publish.gradle.kts
+++ b/gradle/publish.gradle.kts
@@ -54,3 +54,8 @@ configure<PublishingExtension> {
         }
     }
 }
+
+// This makes it difficult to use modern Java and produce usable output.
+tasks.withType<GenerateModuleMetadata> {
+    enabled = false
+}


### PR DESCRIPTION
By default, gradle publishes module metadata. I've had numerous problems with gradle self-destructing over the contents of these files, which are often innocuous. I've chosen to remove it.