### PR TITLE
Use gradle.properties to specify base version once

### DIFF
--- a/dropwizard/build.gradle.kts
+++ b/dropwizard/build.gradle.kts
@@ -8,7 +8,8 @@ group = "com.newrelic.logging"
 // -Prelease=true will render a non-snapshot version
 // All other values (including unset) will render a snapshot version.
 val release: String? by project
-version = "2.0" + if ("true" == release) "" else "-SNAPSHOT"
+val releaseVersion: String by project
+version = releaseVersion + if ("true" == release) "" else "-SNAPSHOT"
 
 repositories {
     mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+releaseVersion=2.1

--- a/jul/build.gradle.kts
+++ b/jul/build.gradle.kts
@@ -8,7 +8,8 @@ group = "com.newrelic.logging"
 // -Prelease=true will render a non-snapshot version
 // All other values (including unset) will render a snapshot version.
 val release: String? by project
-version = "2.0" + if ("true" == release) "" else "-SNAPSHOT"
+val releaseVersion: String by project
+version = releaseVersion + if ("true" == release) "" else "-SNAPSHOT"
 
 repositories {
     mavenCentral()

--- a/log4j1/build.gradle.kts
+++ b/log4j1/build.gradle.kts
@@ -8,7 +8,8 @@ group = "com.newrelic.logging"
 // -Prelease=true will render a non-snapshot version
 // All other values (including unset) will render a snapshot version.
 val release: String? by project
-version = "2.0" + if ("true" == release) "" else "-SNAPSHOT"
+val releaseVersion: String by project
+version = releaseVersion + if ("true" == release) "" else "-SNAPSHOT"
 
 repositories {
     mavenCentral()

--- a/log4j2/build.gradle.kts
+++ b/log4j2/build.gradle.kts
@@ -8,7 +8,8 @@ group = "com.newrelic.logging"
 // -Prelease=true will render a non-snapshot version
 // All other values (including unset) will render a snapshot version.
 val release: String? by project
-version = "2.0" + if ("true" == release) "" else "-SNAPSHOT"
+val releaseVersion: String by project
+version = releaseVersion + if ("true" == release) "" else "-SNAPSHOT"
 
 repositories {
     mavenLocal()

--- a/logback/build.gradle.kts
+++ b/logback/build.gradle.kts
@@ -8,7 +8,8 @@ group = "com.newrelic.logging"
 // -Prelease=true will render a non-snapshot version
 // All other values (including unset) will render a snapshot version.
 val release: String? by project
-version = "2.0" + if ("true" == release) "" else "-SNAPSHOT"
+val releaseVersion: String by project
+version = releaseVersion + if ("true" == release) "" else "-SNAPSHOT"
 
 repositories {
     mavenCentral()

--- a/logback11/build.gradle.kts
+++ b/logback11/build.gradle.kts
@@ -8,7 +8,8 @@ group = "com.newrelic.logging"
 // -Prelease=true will render a non-snapshot version
 // All other values (including unset) will render a snapshot version.
 val release: String? by project
-version = "2.0" + if ("true" == release) "" else "-SNAPSHOT"
+val releaseVersion: String by project
+version = releaseVersion + if ("true" == release) "" else "-SNAPSHOT"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Since all modules are published in one go with the version number getting updated, I thought it helpful to consolidate them.