### PR TITLE
Fix #29: Make maxStackSize configurable

### DIFF
--- a/core/src/main/java/com/newrelic/logging/core/ExceptionUtil.java
+++ b/core/src/main/java/com/newrelic/logging/core/ExceptionUtil.java
@@ -17,12 +17,16 @@ public class ExceptionUtil {
     }
 
     public static String getErrorStack(StackTraceElement[] stack) {
+        return getErrorStack(stack, MAX_STACK_SIZE);
+    }
+
+    public static String getErrorStack(StackTraceElement[] stack, Integer maxStackSize) {
         if (stack == null || stack.length == 0) {
             return null;
         }
 
-        StringBuilder stackBuilder = new StringBuilder();
-        for(int i = 0; i < Math.min(MAX_STACK_SIZE, stack.length); i++) {
+        StringBuilder stackBuilder = new StringBuilder(maxStackSize);
+        for(int i = 0; i < Math.min(maxStackSize, stack.length); i++) {
             stackBuilder.append("  at " + stack[i].toString() + "\n");
         }
         return stackBuilder.toString();

--- a/core/src/main/java/com/newrelic/logging/core/ExceptionUtil.java
+++ b/core/src/main/java/com/newrelic/logging/core/ExceptionUtil.java
@@ -25,7 +25,7 @@ public class ExceptionUtil {
             return null;
         }
 
-        StringBuilder stackBuilder = new StringBuilder(maxStackSize);
+        StringBuilder stackBuilder = new StringBuilder();
         for(int i = 0; i < Math.min(maxStackSize, stack.length); i++) {
             stackBuilder.append("  at " + stack[i].toString() + "\n");
         }

--- a/logback/src/main/java/com/newrelic/logging/logback/NewRelicEncoder.java
+++ b/logback/src/main/java/com/newrelic/logging/logback/NewRelicEncoder.java
@@ -32,7 +32,7 @@ import static com.newrelic.logging.core.ExceptionUtil.MAX_STACK_SIZE;
 public class NewRelicEncoder extends EncoderBase<ILoggingEvent> {
     private NewRelicJsonLayout layout;
 
-    Integer maxStackSize = MAX_STACK_SIZE;
+    private Integer maxStackSize = MAX_STACK_SIZE;
 
     @Override
     public byte[] encode(ILoggingEvent event) {
@@ -51,6 +51,10 @@ public class NewRelicEncoder extends EncoderBase<ILoggingEvent> {
         super.start();
         layout = new NewRelicJsonLayout(maxStackSize);
         layout.start();
+    }
+
+    public void setMaxStackSize(final Integer maxStackSize) {
+        this.maxStackSize = maxStackSize;
     }
 
     @Override

--- a/logback/src/main/java/com/newrelic/logging/logback/NewRelicEncoder.java
+++ b/logback/src/main/java/com/newrelic/logging/logback/NewRelicEncoder.java
@@ -12,6 +12,8 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
+import static com.newrelic.logging.core.ExceptionUtil.MAX_STACK_SIZE;
+
 /**
  * An {@link ch.qos.logback.core.encoder.Encoder} that will write New Relic's JSON format.
  *
@@ -28,7 +30,9 @@ import java.util.Arrays;
  * @see <a href="https://logback.qos.ch/manual/encoders.html#interface">Logback Encoders</a>
  */
 public class NewRelicEncoder extends EncoderBase<ILoggingEvent> {
-    private NewRelicJsonLayout layout = new NewRelicJsonLayout();
+    private NewRelicJsonLayout layout;
+
+    Integer maxStackSize = MAX_STACK_SIZE;
 
     @Override
     public byte[] encode(ILoggingEvent event) {
@@ -45,6 +49,7 @@ public class NewRelicEncoder extends EncoderBase<ILoggingEvent> {
     @Override
     public void start() {
         super.start();
+        layout = new NewRelicJsonLayout(maxStackSize);
         layout.start();
     }
 

--- a/logback/src/main/java/com/newrelic/logging/logback/NewRelicJsonLayout.java
+++ b/logback/src/main/java/com/newrelic/logging/logback/NewRelicJsonLayout.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import static com.newrelic.logging.core.ExceptionUtil.MAX_STACK_SIZE;
 
 public class NewRelicJsonLayout extends LayoutBase<ILoggingEvent> {
-    private Integer maxStackSize;
+    private final Integer maxStackSize;
 
     public NewRelicJsonLayout() {
         this(MAX_STACK_SIZE);

--- a/logback/src/main/java/com/newrelic/logging/logback/NewRelicJsonLayout.java
+++ b/logback/src/main/java/com/newrelic/logging/logback/NewRelicJsonLayout.java
@@ -23,6 +23,16 @@ import java.util.Map;
 import static com.newrelic.logging.core.ExceptionUtil.MAX_STACK_SIZE;
 
 public class NewRelicJsonLayout extends LayoutBase<ILoggingEvent> {
+    private Integer maxStackSize;
+
+    public NewRelicJsonLayout() {
+        this(MAX_STACK_SIZE);
+    }
+
+    public NewRelicJsonLayout(Integer maxStackSize) {
+        this.maxStackSize = maxStackSize;
+    }
+
     @Override
     public String doLayout(ILoggingEvent event) {
         StringWriter sw = new StringWriter();
@@ -67,12 +77,12 @@ public class NewRelicJsonLayout extends LayoutBase<ILoggingEvent> {
 
             StackTraceElementProxy[] stackProxy = proxy.getStackTraceElementProxyArray();
             if (stackProxy != null && stackProxy.length > 0) {
-                List<StackTraceElement> elements = new ArrayList<>(MAX_STACK_SIZE);
-                for (int i = 0; i < MAX_STACK_SIZE && i < stackProxy.length; i++) {
+                List<StackTraceElement> elements = new ArrayList<>(maxStackSize);
+                for (int i = 0; i < maxStackSize && i < stackProxy.length; i++) {
                     elements.add(stackProxy[i].getStackTraceElement());
                 }
 
-                generator.writeObjectField(ElementName.ERROR_STACK, ExceptionUtil.getErrorStack(elements.toArray(new StackTraceElement[0])));
+                generator.writeObjectField(ElementName.ERROR_STACK, ExceptionUtil.getErrorStack(elements.toArray(new StackTraceElement[0]), maxStackSize));
             }
         }
 


### PR DESCRIPTION
Allows configuring the maxStackSize on the `NewRelicEncoder` for logback.