### PR TITLE
Added support for custom key values metrics in addition to MDC

### DIFF
--- a/logback/src/main/java/com/newrelic/logging/logback/CustomArgument.java
+++ b/logback/src/main/java/com/newrelic/logging/logback/CustomArgument.java
@@ -1,0 +1,23 @@
+package com.newrelic.logging.logback;
+
+public class CustomArgument {
+    private final String key;
+    private final String value;
+
+    public CustomArgument(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public static CustomArgument keyValue(String key, String value) {
+        return new CustomArgument(key, value);
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/logback/src/main/java/com/newrelic/logging/logback/NewRelicJsonLayout.java
+++ b/logback/src/main/java/com/newrelic/logging/logback/NewRelicJsonLayout.java
@@ -69,6 +69,16 @@ public class NewRelicJsonLayout extends LayoutBase<ILoggingEvent> {
             }
         }
 
+        Object[] customArgumentArray = event.getArgumentArray();
+        if (customArgumentArray != null) {
+            for (Object oneCustomArgumentObject : customArgumentArray) {
+                if (oneCustomArgumentObject instanceof CustomArgument) {
+                    CustomArgument customArgument = (CustomArgument) oneCustomArgumentObject;
+                    generator.writeStringField(customArgument.getKey(), customArgument.getValue());
+                }
+            }
+        }
+
         IThrowableProxy proxy = event.getThrowableProxy();
         if (proxy != null) {
             generator.writeObjectField(ElementName.ERROR_CLASS, proxy.getClassName());


### PR DESCRIPTION
This PR is to add support for custom metrics in the JSON log in addition to MDC. 

Reason for the fix:
Apps that are written in spring 5.x would be asynchronous and non-blocking. As a result of this, there is no guarantee that the thread in which MDC has been set would be executing the log statements. Since MDC is local to a thread, unless we pass the MDC context between threads, there is no guarantee that the thread executing a log statement has the desired MDC values. Passing MDC context between threads for every log would be a performance issue.

Fix: 
Logstash encoder supports StructuredArguments to add custom attributes to the JSON log https://javadoc.io/static/net.logstash.logback/logstash-logback-encoder/4.6/net/logstash/logback/argument/StructuredArgument.html. Implemented a similar functionality here.

Usage:
import static com.newrelic.logging.logback.CustomArgument.keyValue;
logger.info("Custom log", keyValue("customKey", "customValue"));