### PR TITLE
update log4j compile time dep

### DIFF
--- a/dropwizard/build.gradle.kts
+++ b/dropwizard/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
     implementation("io.dropwizard:dropwizard-request-logging:1.3.14")
     implementation("javax.servlet:javax.servlet-api:3.1.0")
 
-    implementation("com.newrelic.agent.java:newrelic-api:5.6.0")
+    implementation("com.newrelic.agent.java:newrelic-api:7.4.2")
     includeInJar(project(":logback")) {
         isTransitive = false
     }

--- a/examples/dropwizard-app/build.gradle.kts
+++ b/examples/dropwizard-app/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 dependencies {
     implementation("io.dropwizard:dropwizard-core:1.3.14")
     implementation(project(":dropwizard"))
-    implementation("com.newrelic.agent.java:newrelic-api:5.6.0")
+    implementation("com.newrelic.agent.java:newrelic-api:7.4.2")
 }
 
 configure<JavaPluginConvention> {

--- a/examples/jul-app/build.gradle.kts
+++ b/examples/jul-app/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
     implementation(project(":jul"))
-    implementation("com.newrelic.agent.java:newrelic-api:5.6.0")
+    implementation("com.newrelic.agent.java:newrelic-api:7.4.2")
 }
 
 

--- a/examples/log4j1-app/build.gradle.kts
+++ b/examples/log4j1-app/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
 
     implementation("log4j:log4j:1.2.17")
     implementation("com.fasterxml.jackson.core:jackson-core:2.11.1")
-    implementation("com.newrelic.agent.java:newrelic-api:5.6.0")
+    implementation("com.newrelic.agent.java:newrelic-api:7.4.2")
 }
 
 

--- a/examples/log4j2-app/build.gradle.kts
+++ b/examples/log4j2-app/build.gradle.kts
@@ -11,13 +11,13 @@ repositories {
 }
 
 dependencies {
-    implementation("org.apache.logging.log4j:log4j-api:2.13.1")
-    implementation("org.apache.logging.log4j:log4j-core:2.13.1")
+    implementation("org.apache.logging.log4j:log4j-api:2.16.0")
+    implementation("org.apache.logging.log4j:log4j-core:2.16.0")
     runtimeOnly(project(":log4j2"))
 
     implementation("com.fasterxml.jackson.core:jackson-core:2.11.1")
     implementation("com.lmax:disruptor:3.4.2")
-    implementation("com.newrelic.agent.java:newrelic-api:5.6.0")
+    implementation("com.newrelic.agent.java:newrelic-api:7.4.2")
 }
 
 

--- a/examples/logback-app/build.gradle.kts
+++ b/examples/logback-app/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     implementation("ch.qos.logback:logback-classic:1.2.3")
     implementation("com.fasterxml.jackson.core:jackson-core:2.11.1")
 
-    implementation("com.newrelic.agent.java:newrelic-api:5.6.0")
+    implementation("com.newrelic.agent.java:newrelic-api:7.4.2")
 }
 
 

--- a/examples/logback11-app/build.gradle.kts
+++ b/examples/logback11-app/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     implementation("ch.qos.logback:logback-classic:1.1.1")
     implementation("com.fasterxml.jackson.core:jackson-core:2.11.1")
 
-    implementation("com.newrelic.agent.java:newrelic-api:5.6.0")
+    implementation("com.newrelic.agent.java:newrelic-api:7.4.2")
 }
 
 

--- a/jul/build.gradle.kts
+++ b/jul/build.gradle.kts
@@ -21,7 +21,7 @@ configurations["compileOnly"].extendsFrom(includeInJar)
 
 dependencies {
     implementation("com.fasterxml.jackson.core:jackson-core:2.11.1")
-    implementation("com.newrelic.agent.java:newrelic-api:5.6.0")
+    implementation("com.newrelic.agent.java:newrelic-api:7.4.2")
     includeInJar(project(":core"))
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")

--- a/log4j1/build.gradle.kts
+++ b/log4j1/build.gradle.kts
@@ -22,7 +22,7 @@ configurations["compileOnly"].extendsFrom(includeInJar)
 dependencies {
     implementation("com.fasterxml.jackson.core:jackson-core:2.11.1")
     implementation("log4j:log4j:1.2.17")
-    implementation("com.newrelic.agent.java:newrelic-api:5.6.0")
+    implementation("com.newrelic.agent.java:newrelic-api:7.4.2")
     includeInJar(project(":core"))
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")

--- a/log4j2/build.gradle.kts
+++ b/log4j2/build.gradle.kts
@@ -21,10 +21,10 @@ val includeInJar: Configuration by configurations.creating
 configurations["compileOnly"].extendsFrom(includeInJar)
 
 dependencies {
-    annotationProcessor("org.apache.logging.log4j:log4j-core:2.13.3")
+    annotationProcessor("org.apache.logging.log4j:log4j-core:2.16.0")
     implementation("com.fasterxml.jackson.core:jackson-core:2.11.1")
-    implementation("org.apache.logging.log4j:log4j-core:2.13.3")
-    implementation("com.newrelic.agent.java:newrelic-api:5.6.0")
+    implementation("org.apache.logging.log4j:log4j-core:2.16.0")
+    implementation("com.newrelic.agent.java:newrelic-api:7.4.2")
     includeInJar(project(":core"))
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")

--- a/logback/build.gradle.kts
+++ b/logback/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-core:2.11.1")
     implementation("ch.qos.logback:logback-core:1.2.0")
     implementation("ch.qos.logback:logback-classic:1.2.0")
-    implementation("com.newrelic.agent.java:newrelic-api:5.6.0")
+    implementation("com.newrelic.agent.java:newrelic-api:7.4.2")
     includeInJar(project(":core"))
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")

--- a/logback11/build.gradle.kts
+++ b/logback11/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-core:2.11.1")
     implementation("ch.qos.logback:logback-core:1.1.1")
     implementation("ch.qos.logback:logback-classic:1.1.1")
-    implementation("com.newrelic.agent.java:newrelic-api:5.6.0")
+    implementation("com.newrelic.agent.java:newrelic-api:7.4.2")
     includeInJar(project(":core"))
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")

--- a/performance/log4j2-perf/build.gradle.kts
+++ b/performance/log4j2-perf/build.gradle.kts
@@ -13,10 +13,10 @@ repositories {
 dependencies {
     implementation(project(":log4j2"))
 
-    implementation("org.apache.logging.log4j:log4j-api:2.12.0")
+    implementation("org.apache.logging.log4j:log4j-api:2.16.0")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.11.1")
     implementation("com.lmax:disruptor:3.4.2")
-    implementation("com.newrelic.agent.java:newrelic-api:5.6.0")
+    implementation("com.newrelic.agent.java:newrelic-api:7.4.2")
 }
 
 


### PR DESCRIPTION
This isn't really a fix per se.  We don't actually bundle the log4j jar. It's only used at compile time and the log extension user's version is what is used at runtime. So the extension itself isn't vulnerable to the attack in https://issues.apache.org/jira/browse/LOG4J2-3201 .

However, we are updating the dependency to 2.15.0, mainly to avoid it making folks feel uneasy and needing to address questions about whether the extension is vulnerable.

