### PR TITLE
feat: newrelic log-forwarder for logback

### DIFF
--- a/dropwizard/build.gradle.kts
+++ b/dropwizard/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
     implementation("io.dropwizard:dropwizard-request-logging:1.3.14")
     implementation("javax.servlet:javax.servlet-api:3.1.0")
 
-    implementation("com.newrelic.agent.java:newrelic-api:7.4.3")
+    implementation("com.newrelic.agent.java:newrelic-api:7.6.0")
     includeInJar(project(":logback")) {
         isTransitive = false
     }

--- a/examples/dropwizard-app/build.gradle.kts
+++ b/examples/dropwizard-app/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 dependencies {
     implementation("io.dropwizard:dropwizard-core:1.3.14")
     implementation(project(":dropwizard"))
-    implementation("com.newrelic.agent.java:newrelic-api:7.4.3")
+    implementation("com.newrelic.agent.java:newrelic-api:7.6.0")
 }
 
 configure<JavaPluginConvention> {

--- a/examples/jul-app/build.gradle.kts
+++ b/examples/jul-app/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
     implementation(project(":jul"))
-    implementation("com.newrelic.agent.java:newrelic-api:7.4.3")
+    implementation("com.newrelic.agent.java:newrelic-api:7.6.0")
 }
 
 

--- a/examples/log4j1-app/build.gradle.kts
+++ b/examples/log4j1-app/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
 
     implementation("log4j:log4j:1.2.17")
     implementation("com.fasterxml.jackson.core:jackson-core:2.11.1")
-    implementation("com.newrelic.agent.java:newrelic-api:7.4.3")
+    implementation("com.newrelic.agent.java:newrelic-api:7.6.0")
 }
 
 

--- a/examples/log4j2-app/build.gradle.kts
+++ b/examples/log4j2-app/build.gradle.kts
@@ -11,13 +11,13 @@ repositories {
 }
 
 dependencies {
-    implementation("org.apache.logging.log4j:log4j-api:2.17.1")
-    implementation("org.apache.logging.log4j:log4j-core:2.17.1")
+    implementation("org.apache.logging.log4j:log4j-api:2.17.2")
+    implementation("org.apache.logging.log4j:log4j-core:2.17.2")
     runtimeOnly(project(":log4j2"))
 
     implementation("com.fasterxml.jackson.core:jackson-core:2.11.1")
     implementation("com.lmax:disruptor:3.4.2")
-    implementation("com.newrelic.agent.java:newrelic-api:7.4.3")
+    implementation("com.newrelic.agent.java:newrelic-api:7.6.0")
 }
 
 

--- a/examples/logback-app/build.gradle.kts
+++ b/examples/logback-app/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     implementation("ch.qos.logback:logback-classic:1.2.3")
     implementation("com.fasterxml.jackson.core:jackson-core:2.11.1")
 
-    implementation("com.newrelic.agent.java:newrelic-api:7.4.3")
+    implementation("com.newrelic.agent.java:newrelic-api:7.6.0")
 }
 
 

--- a/examples/logback11-app/build.gradle.kts
+++ b/examples/logback11-app/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     implementation("ch.qos.logback:logback-classic:1.1.1")
     implementation("com.fasterxml.jackson.core:jackson-core:2.11.1")
 
-    implementation("com.newrelic.agent.java:newrelic-api:7.4.3")
+    implementation("com.newrelic.agent.java:newrelic-api:7.6.0")
 }
 
 

--- a/forwarder/README.md
+++ b/forwarder/README.md
@@ -5,7 +5,7 @@ A log forwarder built using the [New Relic Java Telemetry SDK](https://github.co
 ## Usage 
 
 The `forwarder` module is currently used by the following:
-* [Logback 1.2](../logback/README.md) - See `NewRelicHttpAppender`
+* [Logback 1.2](../logback/README.md#using-the-http-log-forwarder-from-within-your-app) - See `NewRelicHttpAppender`
 
 ## Configuration
 

--- a/forwarder/README.md
+++ b/forwarder/README.md
@@ -1,0 +1,20 @@
+# Log Forwarder
+
+A log forwarder built using the [New Relic Java Telemetry SDK](https://github.com/newrelic/newrelic-telemetry-sdk-java).
+
+## Usage 
+
+The `forwarder` module is currently used by the following:
+* [Logback 1.2](../logback/README.md) - See `NewRelicHttpAppender`
+
+## Configuration
+
+The `forwarder` provides the following configuration options via `LogForwarderConfiguration`:
+* `endpoint`: The `endpoint` defaults to New Relic US production environments (https://log-api.newrelic.com/log/v1) and will need to be configured for other environments (e.g. EU production should instead
+  use https://log-api.eu.newrelic.com/log/v1).
+* `license`: The `license` will be picked up from the java-agent if installed, but you can override it if you want.
+* `maxQueuedLogs`: Maximum number of logs queued in memory waiting to be sent.
+* `maxLogsPerBatch`: Maximum number of logs per batch (request) to NewRelic.
+* `maxTerminationTimeSeconds`: Number of seconds to wait for graceful shutdown of its executor.
+* `flushIntervalSeconds`: Time period and initial delay when scheduling a task at a fixed rate.
+* `maxScheduledLogsToBeAppended`: Maximum scheduled logs to be appended. This is used to prevent the log forwarder from accepting more logs when we reach this number of jobs in the scheduler.

--- a/forwarder/build.gradle.kts
+++ b/forwarder/build.gradle.kts
@@ -10,9 +10,9 @@ repositories {
 }
 
 dependencies {
-    implementation("com.newrelic.agent.java:newrelic-api:7.4.0")
-    implementation("com.newrelic.telemetry:telemetry-core:0.12.0")
-    implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.12.0")
+    implementation("com.newrelic.agent.java:newrelic-api:7.6.0")
+    implementation("com.newrelic.telemetry:telemetry-core:0.13.1")
+    implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.13.1")
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
     testImplementation("org.mockito:mockito-core:3.4.4")

--- a/forwarder/build.gradle.kts
+++ b/forwarder/build.gradle.kts
@@ -1,0 +1,25 @@
+plugins {
+    java
+}
+
+group = "com.newrelic.logging"
+version = "1.0-SNAPSHOT"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("com.newrelic.agent.java:newrelic-api:7.4.0")
+    implementation("com.newrelic.telemetry:telemetry-core:0.12.0")
+    implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.12.0")
+
+    testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
+    testImplementation("org.mockito:mockito-core:3.4.4")
+    testImplementation("ch.qos.logback:logback-classic:1.2.3")
+    testImplementation(project(":core-test"))
+}
+
+tasks.getByName<Test>("test") {
+    useJUnitPlatform()
+}

--- a/forwarder/src/main/java/com/newrelic/logging/forwarder/LogForwarder.java
+++ b/forwarder/src/main/java/com/newrelic/logging/forwarder/LogForwarder.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2019 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.newrelic.logging.forwarder;
+
+import com.newrelic.api.agent.Agent;
+import com.newrelic.api.agent.NewRelic;
+import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.LogBatchSenderFactory;
+import com.newrelic.telemetry.OkHttpPoster;
+import com.newrelic.telemetry.SenderConfiguration;
+import com.newrelic.telemetry.TelemetryClient;
+import com.newrelic.telemetry.logs.Log;
+import com.newrelic.telemetry.logs.LogBatch;
+import com.newrelic.telemetry.logs.LogBatchSender;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+/**
+ * A LogForwarder that will forward the logs using the NewRelic Telemetry SDK.
+ *
+ * This logic is in a separate class, so it can be reused by multiple appender
+ * implementations across different logging libraries.
+ */
+public class LogForwarder {
+
+    private static final String LICENSE_KEY_CONFIG_FIELD = "license_key";
+    private static final boolean USE_DAEMON_THREADS = true;
+    private static final String PLUGIN_TYPE_KEY = "plugin.type";
+
+    private final String pluginType;
+    private final BlockingQueue<Log> logs;
+    private final LogForwarderConfiguration configuration;
+    private final ScheduledThreadPoolExecutor executor;
+    private final LogForwarderNotificationHandler notificationHandler;
+    private TelemetryClient client;
+
+    /**
+     * Initialize {@link TelemetryClient} with a {@link LogBatchSender} that will forward logs to newrelic each second
+     * and also manage the retry logic if the requests are failing.
+     *
+     * LogBatches will be sent to the TelemetryClient each second or each time the limit defined by
+     * {@link LogForwarderConfiguration#getMaxLogsPerBatch()} is reached.
+     *
+     * LogBatches will be forwarded to NewRelic each second by the TelemetryClient.
+     *
+     * Logs will be dropped when {@link LogForwarderConfiguration#getMaxQueuedLogs()} is reached.
+     *
+     * @param givenPluginType the logging library using the forwarder.
+     * @param givenConfiguration the log forwarder configuration.
+     */
+    public LogForwarder(String givenPluginType, LogForwarderConfiguration givenConfiguration) {
+        if (agentSupplier.get() == null) throw new RuntimeException("NewRelic java-log-extensions requires the NewRelic Java Agent installed and set to work.");
+        pluginType = givenPluginType;
+        configuration = givenConfiguration;
+        logs = new LinkedBlockingQueue<>(configuration.getMaxLogsPerBatch());
+        executor = new ScheduledThreadPoolExecutor(1, Threads.daemonNamedThreadFactory("log-batcher-scheduler"));
+        notificationHandler = new LogForwarderNotificationHandler(pluginType);
+    }
+
+    /**
+     * Start the scheduled tasks that:
+     * - Create log batches.
+     * - Notify about dropped logs.
+     *
+     * Start the {@link TelemetryClient} that will send the logs to the NewRelic Log API.
+     */
+    public void start() {
+        executor.scheduleAtFixedRate(this::addBatchWithCurrentLogs, configuration.getFlushIntervalSeconds(), configuration.getFlushIntervalSeconds(), TimeUnit.SECONDS);
+        client = createTelemetryClient(generateSenderConfiguration());
+        client.withNotificationHandler(notificationHandler);
+    }
+
+    /**
+     * Schedule the log to be appended to a LogBatch.
+     *
+     * If the current queue size is bigger than the maxLogsPerBatch we drop the log. We use
+     * the maxLogsPerBatch instead a custom configurations because we only want to limit
+     * the queue somehow to prevent the log forwarder taking so much memory and affecting
+     * the application.
+     *
+     * @param log the log to be appended.
+     */
+    public void append(Log log) {
+        scheduleLog(new RetryableLog(log));
+    }
+
+    /**
+     * Shutdowns the telemetry sdk client and the executor
+     */
+    public void shutdown() {
+        addBatchWithCurrentLogs();
+        if (client != null) {
+            client.shutdown();
+        }
+        if (executor != null) {
+            executor.shutdown();
+        }
+        if (notificationHandler != null) {
+            notificationHandler.shutdown();
+        }
+    }
+
+    /**
+     * Generate a default configuration for the Telemetry SDK.
+     *
+     * @return the sender default configuration.
+     */
+    private SenderConfiguration generateSenderConfiguration() {
+        return LogBatchSenderFactory
+                .fromHttpImplementation(OkHttpPoster::new)
+                .configureWith(getLicense())
+                .endpoint(getEndpoint())
+                .build();
+    }
+
+    /**
+     * Create a telemetry client using the information from {@link LogForwarderConfiguration}.
+     *
+     * We only set the LogBatchSender since is the only one we're going to use.
+     *
+     * @param senderConfiguration the sender configuration.
+     * @return the telemetry client.
+     */
+    protected TelemetryClient createTelemetryClient(SenderConfiguration senderConfiguration) {
+        return new TelemetryClient(
+                null,
+                null,
+                null,
+                LogBatchSender.create(senderConfiguration),
+                configuration.getMaxTerminationTimeSeconds(),
+                USE_DAEMON_THREADS,
+                configuration.getMaxQueuedLogs()
+        );
+    }
+
+    /**
+     * Add a log to the executor queue that will append the given log to the current batch.
+     *
+     * @param retryableLog a log wrapped in a RetryableLog to manage the retrying if needed.
+     */
+    private void scheduleLog(RetryableLog retryableLog) {
+        if (executor.getQueue().size() >= configuration.getMaxScheduledLogsToBeAppended()) {
+            droppedLog();
+        } else {
+            executor.execute(() -> appendWithRetry(retryableLog));
+        }
+    }
+
+    /**
+     * Schedule adding a log to the queue with the back off time provided by the RetryableLog.
+     *
+     * If max retries is reached or the maxQueuedLogAppend is reached, the log will be dropped.
+     *
+     * @param retryableLog the log to be appended.
+     */
+    private void scheduleLogWithDelay(RetryableLog retryableLog) {
+        long waitTime = retryableLog.retryBackOffTime();
+        if (waitTime == -1) {
+            droppedLog();
+            return;
+        }
+
+        if (executor.getQueue().size() >= configuration.getMaxScheduledLogsToBeAppended()) {
+            droppedLog();
+        } else {
+            executor.schedule(() -> scheduleLog(retryableLog), waitTime, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    /**
+     * To avoid blocking the main thread this method should be executed by
+     * a scheduled action.
+     *
+     * If the max of log per batch is raised, then we will create a batch with current
+     * queued logs and send it to the telemetry SDK.
+     *
+     * If the logs queue refuses to add a new log, we schedule a retry..
+     *
+     * @param retryableLog the log to be appended.
+     */
+    private void appendWithRetry(RetryableLog retryableLog) {
+        if (logs.size() >= configuration.getMaxLogsPerBatch()) {
+            addBatchWithCurrentLogs();
+        }
+
+        if (!logs.offer(retryableLog.getLog())) {
+            scheduleLogWithDelay(retryableLog);
+        }
+    }
+
+    /**
+     * Create a batch adding the plugin type attribute for given collection of logs.
+     *
+     * @param logsToBeAdded the logs to be added on the batch.
+     * @return the telemetry log batch object.
+     */
+    private LogBatch createBatch(Collection<Log> logsToBeAdded) {
+        final Attributes attributes = new Attributes();
+        attributes.put(PLUGIN_TYPE_KEY, pluginType);
+        return new LogBatch(logsToBeAdded, attributes);
+    }
+
+    /**
+     * Drain the current logs queue and create a batch with those logs if not empty.
+     *
+     * Empty could occur if the application is not emitting logs and the scheduled action to send logs
+     * is triggered (each getFlushIntervalSeconds).
+     */
+    private void addBatchWithCurrentLogs() {
+        final List<Log> logsToBeAdded = new ArrayList<>();
+        logs.drainTo(logsToBeAdded, configuration.getMaxLogsPerBatch());
+        if (logsToBeAdded.size() > 0) {
+            client.sendBatch(createBatch(logsToBeAdded));
+        }
+    }
+
+    private void droppedLog() {
+        notificationHandler.noticeDroppedLog();
+    }
+
+    /**
+     * Get the endpoint from the configuration.
+     *
+     * The endpoint defaults to the us-production if the customer doesn't provide a custom one in the configuration.
+     *
+     * @return the logs API URL.
+     */
+    private URL getEndpoint() {
+        try {
+            return new URL(configuration.getEndpoint());
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Invalid newrelic log endpoint.", e);
+        }
+    }
+
+    /**
+     * Get the license form the configuration or takes the one given in the agent.
+     *
+     * @return the provided license or fallback to the agent one.
+     */
+    private String getLicense() {
+        if (!configuration.getLicense().isEmpty()) {
+            return configuration.getLicense();
+        }
+        return getAgentLicense();
+    }
+
+    private String getAgentLicense() {
+        return agentSupplier.get().getConfig().getValue(LICENSE_KEY_CONFIG_FIELD);
+    }
+
+    // visible for testing
+    public static Supplier<Agent> agentSupplier = NewRelic::getAgent;
+}

--- a/forwarder/src/main/java/com/newrelic/logging/forwarder/LogForwarder.java
+++ b/forwarder/src/main/java/com/newrelic/logging/forwarder/LogForwarder.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2019 New Relic Corporation. All rights reserved.
+ * Copyright 2022 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package com.newrelic.logging.forwarder;
 
 import com.newrelic.api.agent.Agent;

--- a/forwarder/src/main/java/com/newrelic/logging/forwarder/LogForwarderConfiguration.java
+++ b/forwarder/src/main/java/com/newrelic/logging/forwarder/LogForwarderConfiguration.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2019 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.newrelic.logging.forwarder;
+
+public class LogForwarderConfiguration {
+
+    public static final String DEFAULT_URL = "https://log-api.newrelic.com/log/v1";
+    public static final String DEFAULT_LICENSE = "";
+    public static final int DEFAULT_MAX_LOGS_PER_BATCH = 10_000;
+    public static final int DEFAULT_MAX_QUEUED_LOGS = 100_000;
+    public static final int DEFAULT_MAX_SCHEDULED_LOGS_TO_BE_APPENDED = 1_000;
+    public static final int DEFAULT_MAX_TERMINATION_TIME_SECONDS = 10;
+    public static final int DEFAULT_FLUSH_INTERVAL_SECONDS = 1;
+
+    private final String endpoint;
+    private final String license;
+
+    /**
+     * Maximum number of logs per batch (request) to NewRelic.
+     */
+    private final int maxLogsPerBatch;
+
+    /**
+     * Maximum number of logs queued in memory waiting to be sent.
+     */
+    private final int maxQueuedLogs;
+
+    /**
+     * Maximum scheduled logs to be appended.
+     *
+     * This is used to prevent the log forwarder of accepting more logs when we reach this
+     * number of jobs in the scheduler.
+     */
+    private final int maxScheduledLogsToBeAppended;
+
+    private final int flushIntervalSeconds;
+
+    private final int maxTerminationTimeSeconds;
+
+    private LogForwarderConfiguration(Builder builder) {
+        endpoint = builder.endpoint;
+        license = builder.license;
+        maxLogsPerBatch = builder.maxLogsPerBatch;
+        maxQueuedLogs = builder.maxQueuedLogs;
+        maxTerminationTimeSeconds = builder.maxTerminationTimeSeconds;
+        flushIntervalSeconds = builder.flushIntervalSeconds;
+        maxScheduledLogsToBeAppended = builder.maxScheduledLogsToBeAppended;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public String getLicense() {
+        return license;
+    }
+
+    public int getMaxQueuedLogs() {
+        return maxQueuedLogs;
+    }
+
+    public int getMaxLogsPerBatch() {
+        return maxLogsPerBatch;
+    }
+
+    public int getMaxTerminationTimeSeconds() {
+        return maxTerminationTimeSeconds;
+    }
+
+    public int getFlushIntervalSeconds() {
+        return flushIntervalSeconds;
+    }
+
+    public int getMaxScheduledLogsToBeAppended() {
+        return maxScheduledLogsToBeAppended;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String endpoint = DEFAULT_URL;
+        private String license = DEFAULT_LICENSE;
+        private int maxQueuedLogs = DEFAULT_MAX_QUEUED_LOGS;
+        private int maxLogsPerBatch = DEFAULT_MAX_LOGS_PER_BATCH;
+        private int maxTerminationTimeSeconds = DEFAULT_MAX_TERMINATION_TIME_SECONDS;
+        private int flushIntervalSeconds = DEFAULT_FLUSH_INTERVAL_SECONDS;
+        private int maxScheduledLogsToBeAppended = DEFAULT_MAX_SCHEDULED_LOGS_TO_BE_APPENDED;
+
+        private Builder() {}
+
+        public Builder setEndpoint(String givenEndpoint) {
+            endpoint = givenEndpoint;
+            return this;
+        }
+
+        public Builder setLicense(String givenLicense) {
+            license = givenLicense;
+            return this;
+        }
+
+        public Builder setMaxQueuedLogs(int givenMaxQueuedLogs) {
+            maxQueuedLogs = givenMaxQueuedLogs;
+            return this;
+        }
+
+        public Builder setMaxLogsPerBatch(int givenMaxLogsPerBatch) {
+            maxLogsPerBatch = givenMaxLogsPerBatch;
+            return this;
+        }
+
+        public Builder setMaxTerminationTimeSeconds(int givenMaxTerminationTimeSeconds) {
+            maxTerminationTimeSeconds = givenMaxTerminationTimeSeconds;
+            return this;
+        }
+
+        public Builder setFlushIntervalSeconds(int givenFlushIntervalSeconds) {
+            flushIntervalSeconds = givenFlushIntervalSeconds;
+            return this;
+        }
+
+        public Builder setMaxScheduledLogsToBeAppended(int givenMaxScheduledLogsToBeAppended) {
+            maxScheduledLogsToBeAppended = givenMaxScheduledLogsToBeAppended;
+            return this;
+        }
+
+        public LogForwarderConfiguration build() {
+            return new LogForwarderConfiguration(this);
+        }
+    }
+
+}

--- a/forwarder/src/main/java/com/newrelic/logging/forwarder/LogForwarderConfiguration.java
+++ b/forwarder/src/main/java/com/newrelic/logging/forwarder/LogForwarderConfiguration.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2019 New Relic Corporation. All rights reserved.
+ * Copyright 2022 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package com.newrelic.logging.forwarder;
 
 public class LogForwarderConfiguration {
@@ -30,13 +31,19 @@ public class LogForwarderConfiguration {
     /**
      * Maximum scheduled logs to be appended.
      *
-     * This is used to prevent the log forwarder of accepting more logs when we reach this
+     * This is used to prevent the log forwarder from accepting more logs when we reach this
      * number of jobs in the scheduler.
      */
     private final int maxScheduledLogsToBeAppended;
 
+    /**
+     * Time period and initial delay when scheduling a task at a fixed rate.
+     */
     private final int flushIntervalSeconds;
 
+    /**
+     * Number of seconds to wait for graceful shutdown of its executor.
+     */
     private final int maxTerminationTimeSeconds;
 
     private LogForwarderConfiguration(Builder builder) {

--- a/forwarder/src/main/java/com/newrelic/logging/forwarder/LogForwarderNotificationHandler.java
+++ b/forwarder/src/main/java/com/newrelic/logging/forwarder/LogForwarderNotificationHandler.java
@@ -1,0 +1,100 @@
+package com.newrelic.logging.forwarder;
+
+import com.newrelic.api.agent.NewRelic;
+import com.newrelic.telemetry.NotificationHandler;
+import com.newrelic.telemetry.Telemetry;
+import com.newrelic.telemetry.TelemetryBatch;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A {@link NotificationHandler} that handle errors and information messages generated
+ * by the telemetry SDK and forward them to NewRelic.
+ *
+ * Telemetry SDK default handler is logging based, and it doesn't help use in case
+ * we can't forward the logs to NewRelic because an error.
+ *
+ * It relies on the {@link NewRelic} {@link com.newrelic.api.agent.Agent} since is a
+ * common dependency for all the logging extensions contained on this project.
+ *
+ * If the Telemetry SDK notify about a retryable message, this notification handler
+ * informs NewRelic generating an event on NrIntegrationError with the message. This
+ * will be useful when customer want to tune-up their log forwarder (in case that logs
+ * are being split, or they're hitting the API rate-limiting)
+ *
+ * If any error is noticed from the Telemetry SDK we sent it directly to NewRelic as
+ * an error (APM) but also register the amount of dropped logs produced by it.
+ *
+ * This notification handler inform NewRelic about dropped logs in two ways, one is
+ * adding a NrIntegrationError every 30 seconds with the amount of dropped logs. The
+ * other one is sending the metric `droppedLogs` to a custom event named
+ * "LogForwarderMonitoring".
+ */
+public class LogForwarderNotificationHandler implements NotificationHandler {
+
+    private final String pluginType;
+    private final AtomicInteger droppedLogs = new AtomicInteger();
+    private final ScheduledThreadPoolExecutor executor;
+
+    public LogForwarderNotificationHandler(String givenPluginType) {
+        pluginType = givenPluginType;
+        executor = new ScheduledThreadPoolExecutor(1, Threads.daemonNamedThreadFactory("log-notification-scheduler"));
+        executor.scheduleAtFixedRate(this::notifyDroppedLogs, 30, 30, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void noticeError(String message, Throwable throwable, TelemetryBatch<? extends Telemetry> batch) {
+        incrementDroppedLogsCounter(batch.size());
+        Map<String, Object> attributes = agentAttributes();
+        attributes.put("batch.size", batch.size());
+        NewRelic.noticeError(throwable, attributes);
+    }
+
+    @Override
+    public void noticeInfo(String message, Exception exception, TelemetryBatch<? extends Telemetry> batch) {
+        Map<String, Object> attributes = agentAttributes();
+        attributes.put("batch.size", batch.size());
+        attributes.put("message", message);
+        if (exception != null) {
+            attributes.put("exception.message", exception.getMessage());
+            attributes.put("exception.stacktrace", exception.getStackTrace());
+        }
+        NewRelic.getAgent().getInsights().recordCustomEvent("NrIntegrationError", attributes);
+    }
+
+    /**
+     * Notice that a log line has been dropped.
+     */
+    public void noticeDroppedLog() {
+        incrementDroppedLogsCounter(1);
+    }
+
+    /**
+     * Shutdown the executor.
+     */
+    public void shutdown() {
+        executor.shutdown();
+    }
+
+    private void incrementDroppedLogsCounter(int count) {
+        droppedLogs.addAndGet(count);
+        NewRelic.incrementCounter(String.format("Custom/LogForwarderMonitoring/%s/droppedLogs", pluginType), count);
+    }
+
+    private Map<String, Object> agentAttributes() {
+        return new HashMap<>(NewRelic.getAgent().getLinkingMetadata());
+    }
+
+    private void notifyDroppedLogs() {
+        if (droppedLogs.get() > 0) {
+            int currentDroppedLogs = droppedLogs.getAndSet(0);
+            Map<String, Object> attributes = agentAttributes();
+            attributes.put("message", "Dropped " + currentDroppedLogs + " logs.");
+            NewRelic.getAgent().getInsights().recordCustomEvent("NrIntegrationError", attributes);
+        }
+    }
+}

--- a/forwarder/src/main/java/com/newrelic/logging/forwarder/LogForwarderNotificationHandler.java
+++ b/forwarder/src/main/java/com/newrelic/logging/forwarder/LogForwarderNotificationHandler.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.newrelic.logging.forwarder;
 
 import com.newrelic.api.agent.NewRelic;

--- a/forwarder/src/main/java/com/newrelic/logging/forwarder/RetryableLog.java
+++ b/forwarder/src/main/java/com/newrelic/logging/forwarder/RetryableLog.java
@@ -1,0 +1,22 @@
+package com.newrelic.logging.forwarder;
+
+import com.newrelic.telemetry.Backoff;
+import com.newrelic.telemetry.logs.Log;
+
+public class RetryableLog {
+    private final Backoff backoff;
+    private final Log log;
+
+    public RetryableLog(Log givenLog) {
+        log = givenLog;
+        backoff = Backoff.defaultBackoff();
+    }
+
+    public Log getLog() {
+        return log;
+    }
+
+    public long retryBackOffTime() {
+        return backoff.nextWaitMs();
+    }
+}

--- a/forwarder/src/main/java/com/newrelic/logging/forwarder/RetryableLog.java
+++ b/forwarder/src/main/java/com/newrelic/logging/forwarder/RetryableLog.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2022 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.newrelic.logging.forwarder;
 
 import com.newrelic.telemetry.Backoff;

--- a/forwarder/src/main/java/com/newrelic/logging/forwarder/Threads.java
+++ b/forwarder/src/main/java/com/newrelic/logging/forwarder/Threads.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.newrelic.logging.forwarder;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Utility class to provide thread factories generators
+ */
+public class Threads {
+
+    private Threads() {}
+
+    private static final ConcurrentHashMap<String, AtomicInteger> threadCounters = new ConcurrentHashMap<>();
+
+    public static ThreadFactory daemonNamedThreadFactory(String threadName) {
+        final int threadNumber = threadCounters.computeIfAbsent(threadName, k -> new AtomicInteger()).incrementAndGet();
+        final String numberedName = threadName + "-" + threadNumber;
+
+        return runnable -> {
+            Thread thread = Executors.defaultThreadFactory().newThread(runnable);
+            thread.setName(numberedName);
+            thread.setDaemon(true);
+            return thread;
+        };
+    }
+
+}

--- a/forwarder/src/main/java/com/newrelic/logging/forwarder/Threads.java
+++ b/forwarder/src/main/java/com/newrelic/logging/forwarder/Threads.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2019 New Relic Corporation. All rights reserved.
+ * Copyright 2022 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package com.newrelic.logging.forwarder;
 
 import java.util.concurrent.ConcurrentHashMap;

--- a/forwarder/src/test/java/com/newrelic/logging/forwarder/LogForwarderTest.java
+++ b/forwarder/src/test/java/com/newrelic/logging/forwarder/LogForwarderTest.java
@@ -1,0 +1,140 @@
+package com.newrelic.logging.forwarder;
+
+import ch.qos.logback.classic.Level;
+import com.newrelic.api.agent.Agent;
+import com.newrelic.api.agent.Config;
+import com.newrelic.telemetry.TelemetryClient;
+import com.newrelic.telemetry.logs.Log;
+import com.newrelic.telemetry.logs.LogBatch;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.net.MalformedURLException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+public class LogForwarderTest {
+
+    private static final int FIVE_SECONDS = 5_000;
+
+    private static final Log LOG = Log.builder().level(Level.ERROR.levelStr).message("a sample error log").build();
+
+    private LogForwarder forwarder;
+    private TelemetryClient telemetryClient;
+    private LogBatch sentLogBatch;
+
+    @Test
+    @Timeout(3)
+    void shouldWorkCorrectly() {
+        givenAMockedTelemetryClient();
+        givenAStartedForwarderInstanceWithDefaultConfiguration();
+        whenAppendingALog(LOG);
+        thenSendBatchFromTelemetryClientShouldBeCalled(1);
+        thenSentBatchShouldContainTheLog(LOG);
+    }
+
+    @Test
+    @Timeout(3)
+    void shouldEmitNotificationErrorIfAnErrorOccurs() {
+        givenAMockedTelemetryClient();
+        givenAStartedForwarderInstanceWithDefaultConfiguration();
+        whenAppendingALog(LOG);
+    }
+
+    @Test
+    @Timeout(10)
+    void shouldCreateANewLogBatchIfMaxLogsPerBatchIsReached() throws MalformedURLException {
+        givenAMockedTelemetryClient();
+        givenAStartedForwarderInstanceWithCustomPerBatchConfiguration();
+        IntStream.range(0, 20).parallel().forEach(ignored -> whenAppendingALog(LOG));
+        thenSendBatchFromTelemetryClientShouldBeCalled(2);
+    }
+
+    @Test
+    @Timeout(3)
+    void shouldInitializeTelemetryClientUsingConfigurationLicenseAndEndpoint() throws MalformedURLException {
+        givenAMockedTelemetryClient();
+        givenAForwarderInstanceWithCustomLicenseAndEndpointConfiguration();
+    }
+
+    private void givenAMockedTelemetryClient() {
+        telemetryClient = Mockito.mock(TelemetryClient.class);
+    }
+
+    private void givenAForwarderInstanceWithCustomLicenseAndEndpointConfiguration() throws MalformedURLException {
+        LogForwarderConfiguration configuration =
+                LogForwarderConfiguration.builder()
+                        .setEndpoint("https://custom-endpoint/log/v1")
+                        .setLicense("a-custom-license")
+                        .build();
+        forwarder = Mockito.spy(new LogForwarder("testing-library", configuration));
+    }
+
+    private void givenAStartedForwarderInstanceWithDefaultConfiguration() {
+        LogForwarderConfiguration configuration = LogForwarderConfiguration.builder().build();
+        forwarder = Mockito.spy(new LogForwarder("testing-library", configuration));
+        Mockito.doReturn(telemetryClient).when(forwarder).createTelemetryClient(any());
+        forwarder.start();
+    }
+
+    private void givenAStartedForwarderInstanceWithCustomPerBatchConfiguration() {
+        LogForwarderConfiguration configuration = LogForwarderConfiguration.builder()
+                .setMaxLogsPerBatch(10)
+                .build();
+        forwarder = Mockito.spy(new LogForwarder("testing-library", configuration));
+        Mockito.doReturn(telemetryClient).when(forwarder).createTelemetryClient(any());
+        forwarder.start();
+    }
+
+    private void whenAppendingALog(Log log) {
+        forwarder.append(log);
+    }
+
+    private void thenSentBatchShouldContainTheLog(Log log) {
+        assertEquals(1, sentLogBatch.size());
+        assertTrue(sentLogBatch.getTelemetry().contains(log));
+    }
+
+    private void thenSendBatchFromTelemetryClientShouldBeCalled(int atLeast) {
+        ArgumentCaptor<LogBatch> capturedBatch = ArgumentCaptor.forClass(LogBatch.class);
+        Mockito.verify(telemetryClient, Mockito.timeout(FIVE_SECONDS).atLeast(atLeast)).sendBatch(capturedBatch.capture());
+        sentLogBatch = capturedBatch.getValue();
+    }
+
+    private void mockAgent() {
+        // Agent mock
+        Config config = Mockito.mock(Config.class);
+        Agent agent = Mockito.mock(Agent.class);
+        Mockito.when(config.getValue(eq("license_key"))).thenReturn("a-sample-license-key");
+        Mockito.when(agent.getConfig()).thenReturn(config);
+
+        // Agent mocked attributes
+        Map<String, String> attributesMap = new HashMap<>();
+        attributesMap.put("some.agent.key", "an-agent-value");
+        Mockito.when(agent.getLinkingMetadata()).thenReturn(attributesMap);
+
+        // Replace agent supplier
+        LogForwarder.agentSupplier = () -> agent;
+    }
+
+    @BeforeEach
+    void init() {
+        mockAgent();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        forwarder.shutdown();
+    }
+
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-releaseVersion=2.3.1
+releaseVersion=2.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-releaseVersion=2.4
+releaseVersion=2.4.0

--- a/jul/build.gradle.kts
+++ b/jul/build.gradle.kts
@@ -21,7 +21,7 @@ configurations["compileOnly"].extendsFrom(includeInJar)
 
 dependencies {
     implementation("com.fasterxml.jackson.core:jackson-core:2.11.1")
-    implementation("com.newrelic.agent.java:newrelic-api:7.4.3")
+    implementation("com.newrelic.agent.java:newrelic-api:7.6.0")
     includeInJar(project(":core"))
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")

--- a/log4j1/build.gradle.kts
+++ b/log4j1/build.gradle.kts
@@ -22,7 +22,7 @@ configurations["compileOnly"].extendsFrom(includeInJar)
 dependencies {
     implementation("com.fasterxml.jackson.core:jackson-core:2.11.1")
     implementation("log4j:log4j:1.2.17")
-    implementation("com.newrelic.agent.java:newrelic-api:7.4.3")
+    implementation("com.newrelic.agent.java:newrelic-api:7.6.0")
     includeInJar(project(":core"))
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")

--- a/log4j2/build.gradle.kts
+++ b/log4j2/build.gradle.kts
@@ -21,10 +21,10 @@ val includeInJar: Configuration by configurations.creating
 configurations["compileOnly"].extendsFrom(includeInJar)
 
 dependencies {
-    annotationProcessor("org.apache.logging.log4j:log4j-core:2.17.1")
+    annotationProcessor("org.apache.logging.log4j:log4j-core:2.17.2")
     implementation("com.fasterxml.jackson.core:jackson-core:2.11.1")
-    implementation("org.apache.logging.log4j:log4j-core:2.17.1")
-    implementation("com.newrelic.agent.java:newrelic-api:7.4.3")
+    implementation("org.apache.logging.log4j:log4j-core:2.17.2")
+    implementation("com.newrelic.agent.java:newrelic-api:7.6.0")
     includeInJar(project(":core"))
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")

--- a/logback/README.md
+++ b/logback/README.md
@@ -16,7 +16,6 @@ Logback Extension. All steps are required.
 Refer to [Maven Central](https://search.maven.org/search?q=g:com.newrelic.logging%20a:logback) for the appropriate snippets.
 
 ### 2. Configure a `logback appender` element with a `NewRelicEncoder` or a `NewRelicHttpAppender` if you want to send
-logs without an external log forwarder.
 
 #### Using an external log forwarder like the infra-agent (fluent-bit), fluentd or others.
 
@@ -51,8 +50,7 @@ external log forwarders is not an option. For that you should configure the `New
     </appender>
 ```
 
-The license will be picked up from the java-agent if installed, but you can override it if you want.
-The endpoint need to be set for other cases different to NewRelic US endpoint, which is the default.
+See the [forwarder README](../forwarder/README.md#configuration) for a full description of the `NewRelicHttpAppender` config properties shown above.
 
 ### 3. `NewRelicAsyncAppender` must wrap any appenders that will target New Relic's log forwarder
 

--- a/logback/README.md
+++ b/logback/README.md
@@ -15,8 +15,10 @@ Logback Extension. All steps are required.
 
 Refer to [Maven Central](https://search.maven.org/search?q=g:com.newrelic.logging%20a:logback) for the appropriate snippets.
 
+### 2. Configure a `logback appender` element with a `NewRelicEncoder` or a `NewRelicHttpAppender` if you want to send
+logs without an external log forwarder.
 
-### 2. Configure an `<appender>` element with a `NewRelicEncoder`.
+#### Using an external log forwarder like the infra-agent (fluent-bit), fluentd or others.
 
 Update your logging configuration xml to include the `<encoder>` element like below.
 
@@ -31,6 +33,27 @@ Update your logging configuration xml to include the `<encoder>` element like be
 that our log forwarder plugins and back end rely on. At this time, we don't support any customization
 of that format.
 
+#### Using the http log forwarder from within your app.
+
+We provide an HTTP log forwarder within the logback extension that will fit for some use cases where install
+external log forwarders is not an option. For that you should configure the `NewRelicHttpAppender` as follows.
+
+```xml
+    <appender name="HTTP" class="com.newrelic.logging.logback.NewRelicHttpAppender">
+        <!-- Those are the default configuration values -->
+        <!-- <endpoint>https://log-api.newrelic.com/log/v1</endpoint> -->
+        <!-- <license></license> -->
+        <!-- <maxQueuedLogs>100000</maxQueuedLogs> -->
+        <!-- <maxLogsPerBatch>10000</maxLogsPerBatch> -->
+        <!-- <maxTerminationTimeSeconds>10</maxTerminationTimeSeconds> -->
+        <!-- <flushIntervalSeconds>1</flushIntervalSeconds> -->
+        <!-- <maxScheduledLogsToBeAppended>1000</maxScheduledLogsToBeAppended> -->
+    </appender>
+```
+
+The license will be picked up from the java-agent if installed, but you can override it if you want.
+The endpoint need to be set for other cases different to NewRelic US endpoint, which is the default.
+
 ### 3. `NewRelicAsyncAppender` must wrap any appenders that will target New Relic's log forwarder
 
 Update your logging configuration xml to add this section. Change `"LOG_FILE"` to the `name` of the appender
@@ -43,7 +66,7 @@ you updated in the previous step.
 ```
 
 *Why?* The New Relic log format includes New Relic-specific data that must be captured on the thread the log message
-is coming from. This appender captures that information before passing to the standard `AsyncAppender` logic.
+is coming from. This appender captures that information before passing to the standard `AsyncAppender` logic. 
 
 ### 4. The Async Appender must be referenced by all loggers
 

--- a/logback/build.gradle.kts
+++ b/logback/build.gradle.kts
@@ -23,8 +23,8 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-core:2.11.1")
     implementation("ch.qos.logback:logback-core:1.2.0")
     implementation("ch.qos.logback:logback-classic:1.2.0")
-    implementation("com.newrelic.telemetry:telemetry-core:0.12.0")
-    implementation("com.newrelic.agent.java:newrelic-api:7.4.3")
+    implementation("com.newrelic.telemetry:telemetry-core:0.13.1")
+    implementation("com.newrelic.agent.java:newrelic-api:7.6.0")
 
     includeInJar(project(":forwarder"))
     includeInJar(project(":core"))

--- a/logback/build.gradle.kts
+++ b/logback/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 }
 
 val includeInJar: Configuration by configurations.creating
-configurations["compileOnly"].extendsFrom(includeInJar)
+configurations["compile"].extendsFrom(includeInJar)
 
 dependencies {
     implementation("com.fasterxml.jackson.core:jackson-core:2.11.1")

--- a/logback/build.gradle.kts
+++ b/logback/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 }
 
 val includeInJar: Configuration by configurations.creating
-configurations["compile"].extendsFrom(includeInJar)
+configurations["compileOnly"].extendsFrom(includeInJar)
 
 dependencies {
     implementation("com.fasterxml.jackson.core:jackson-core:2.11.1")
@@ -32,7 +32,9 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
     testImplementation("com.google.guava:guava:29.0-jre")
     testImplementation("org.mockito:mockito-core:3.4.4")
+    testImplementation(project(":core"))
     testImplementation(project(":core-test"))
+    testImplementation(project(":forwarder"))
 }
 
 val jar by tasks.getting(Jar::class) {

--- a/logback/build.gradle.kts
+++ b/logback/build.gradle.kts
@@ -24,6 +24,9 @@ dependencies {
     implementation("ch.qos.logback:logback-core:1.2.0")
     implementation("ch.qos.logback:logback-classic:1.2.0")
     implementation("com.newrelic.agent.java:newrelic-api:7.4.2")
+    implementation("com.newrelic.telemetry:telemetry-core:0.12.0")
+
+    includeInJar(project(":forwarder"))
     includeInJar(project(":core"))
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")

--- a/logback/spotbugs-filter.xml
+++ b/logback/spotbugs-filter.xml
@@ -15,6 +15,13 @@
     </Match>
     <Match>
         <!--
+          This is not final so that it can be reassigned in tests to inject a mock Agent.
+        -->
+        <Bug pattern="MS_SHOULD_BE_FINAL"/>
+        <Class name="com.newrelic.logging.logback.NewRelicHttpAppender"/>
+    </Match>
+    <Match>
+        <!--
           We have to write to a static because otherwise this value is set based on a classload.
         -->
         <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD"/>

--- a/logback/src/main/java/com/newrelic/logging/logback/NewRelicHttpAppender.java
+++ b/logback/src/main/java/com/newrelic/logging/logback/NewRelicHttpAppender.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2021 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.newrelic.logging.logback;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.ThrowableProxy;
+import ch.qos.logback.core.AppenderBase;
+import com.newrelic.logging.forwarder.LogForwarder;
+import com.newrelic.logging.forwarder.LogForwarderConfiguration;
+import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.logs.Log;
+
+import static com.newrelic.logging.forwarder.LogForwarderConfiguration.DEFAULT_FLUSH_INTERVAL_SECONDS;
+import static com.newrelic.logging.forwarder.LogForwarderConfiguration.DEFAULT_LICENSE;
+import static com.newrelic.logging.forwarder.LogForwarderConfiguration.DEFAULT_MAX_QUEUED_LOGS;
+import static com.newrelic.logging.forwarder.LogForwarderConfiguration.DEFAULT_MAX_LOGS_PER_BATCH;
+import static com.newrelic.logging.forwarder.LogForwarderConfiguration.DEFAULT_MAX_SCHEDULED_LOGS_TO_BE_APPENDED;
+import static com.newrelic.logging.forwarder.LogForwarderConfiguration.DEFAULT_MAX_TERMINATION_TIME_SECONDS;
+import static com.newrelic.logging.forwarder.LogForwarderConfiguration.DEFAULT_URL;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import com.newrelic.api.agent.Agent;
+import com.newrelic.api.agent.NewRelic;
+import com.newrelic.logging.core.ElementName;
+
+/**
+ * An {@link AppenderBase} implementation that will prepare the logs to be forwarded to NewRelic and add them to a log
+ * forwarder that will do the forwarding asynchronously.
+ *
+ * <pre>{@code
+ *     <appender name="HTTP" class="com.newrelic.logging.logback.NewRelicHttpAppender">
+ *     </appender>
+ *
+ *     <root level="INFO">
+ *         <appender-ref ref="HTTP" />
+ *     <root>
+ * }</pre>
+ * <p>
+ * For more configuration/parameter options {@see LogForwarderConfiguration} class and add them to your appender as for
+ * example:
+ *
+ * <pre>{@code
+ *     <appender name="HTTP" class="com.newrelic.logging.logback.NewRelicHttpAppender">
+ *         <endpoint>https://log-api.eu.newrelic.com/log/v1</endpoint>
+ *         <license>YOUR_LICENSE_KEY</license>
+ *         <maxQueuedLogs>1000000</maxQueuedLogs>
+ *         <maxLogsPerBatch>100000</maxLogsPerBatch>
+ *         [...]
+ *     </appender>
+ * }</pre>
+ * <p>
+ * NOTE: License key will default to the one set on the agent configuration, but you can override it.
+ */
+public class NewRelicHttpAppender extends AppenderBase<ILoggingEvent> {
+
+    private LogForwarder forwarder;
+    protected static String PLUGIN_TYPE = "nr-java-logback";
+
+    protected String endpoint = DEFAULT_URL;
+    protected String license = DEFAULT_LICENSE;
+    protected int maxQueuedLogs = DEFAULT_MAX_QUEUED_LOGS;
+    protected int maxLogsPerBatch = DEFAULT_MAX_LOGS_PER_BATCH;
+    protected int maxTerminationTimeSeconds = DEFAULT_MAX_TERMINATION_TIME_SECONDS;
+    protected int flushIntervalSeconds = DEFAULT_FLUSH_INTERVAL_SECONDS;
+    protected int maxScheduledLogsToBeAppended = DEFAULT_MAX_SCHEDULED_LOGS_TO_BE_APPENDED;
+
+    public NewRelicHttpAppender() {
+        setName(NewRelicHttpAppender.class.getCanonicalName());
+    }
+
+    public void setEndpoint(String givenEndpoint) {
+        endpoint = givenEndpoint;
+    }
+
+    public void setLicense(String givenLicense) {
+        license = givenLicense;
+    }
+
+    public void setMaxQueuedLogs(int givenMaxQueuedLogs) {
+        maxQueuedLogs = givenMaxQueuedLogs;
+    }
+
+    public void setMaxLogsPerBatch(int givenMaxLogsPerBatch) {
+        maxLogsPerBatch = givenMaxLogsPerBatch;
+    }
+
+    public void setMaxTerminationTimeSeconds(int givenMaxTerminationTimeSeconds) {
+        maxTerminationTimeSeconds = givenMaxTerminationTimeSeconds;
+    }
+
+    public void setFlushIntervalSeconds(int givenFlushIntervalSeconds) {
+        flushIntervalSeconds = givenFlushIntervalSeconds;
+    }
+
+    public void setMaxScheduledLogsToBeAppended(int givenMaxScheduledLogsToBeAppended) {
+        maxScheduledLogsToBeAppended = givenMaxScheduledLogsToBeAppended;
+    }
+
+    @Override
+    protected void append(ILoggingEvent eventObject) {
+        forwarder.append(encode(eventObject));
+    }
+
+    private Log encode(ILoggingEvent event) {
+        final Attributes attributes = new Attributes();
+
+        attributes.put(ElementName.THREAD_NAME, event.getThreadName());
+        attributes.put(ElementName.LOGGER_NAME, event.getLoggerName());
+
+        agentSupplier.get().getLinkingMetadata().forEach(attributes::put);
+
+        event.getMDCPropertyMap().forEach(attributes::put);
+
+        Optional.ofNullable(event.getArgumentArray()).ifPresent(customArgumentArray -> {
+            for (Object oneCustomArgumentObject : customArgumentArray) {
+                if (oneCustomArgumentObject instanceof CustomArgument) {
+                    CustomArgument customArgument = (CustomArgument) oneCustomArgumentObject;
+                    attributes.put(customArgument.getKey(), customArgument.getValue());
+                }
+            }
+        });
+
+        final Log.LogBuilder builder = Log.builder()
+                .message(event.getFormattedMessage())
+                .level(event.getLevel().toString())
+                .timestamp(event.getTimeStamp())
+                .attributes(attributes);
+
+        Optional
+                .ofNullable((ThrowableProxy) event.getThrowableProxy())
+                .ifPresent(proxy -> builder.throwable(proxy.getThrowable()));
+
+        return builder.build();
+    }
+
+    @Override
+    public void start() {
+        super.start();
+        forwarder = createForwarder(PLUGIN_TYPE, generateLogForwarderConfiguration());
+        forwarder.start();
+    }
+
+    @Override
+    public void stop() {
+        super.stop();
+        forwarder.shutdown();
+    }
+
+    private LogForwarderConfiguration generateLogForwarderConfiguration() {
+        return LogForwarderConfiguration.builder()
+                .setEndpoint(endpoint)
+                .setLicense(license)
+                .setMaxQueuedLogs(maxQueuedLogs)
+                .setMaxScheduledLogsToBeAppended(maxScheduledLogsToBeAppended)
+                .setMaxLogsPerBatch(maxLogsPerBatch)
+                .setMaxTerminationTimeSeconds(maxTerminationTimeSeconds)
+                .setFlushIntervalSeconds(flushIntervalSeconds)
+                .build();
+    }
+
+    protected LogForwarder createForwarder(String givenPluginType, LogForwarderConfiguration configuration) {
+        return new LogForwarder(givenPluginType, configuration);
+    }
+
+    //visible for testing
+    public static Supplier<Agent> agentSupplier = NewRelic::getAgent;
+}

--- a/logback/src/main/java/com/newrelic/logging/logback/NewRelicHttpAppender.java
+++ b/logback/src/main/java/com/newrelic/logging/logback/NewRelicHttpAppender.java
@@ -41,7 +41,7 @@ import com.newrelic.logging.core.ElementName;
  *     <root>
  * }</pre>
  * <p>
- * For more configuration/parameter options {@see LogForwarderConfiguration} class and add them to your appender as for
+ * For more configuration/parameter options @see LogForwarderConfiguration class and add them to your appender as for
  * example:
  *
  * <pre>{@code

--- a/logback/src/test/java/com/newrelic/logging/logback/NewRelicLogbackHttpTests.java
+++ b/logback/src/test/java/com/newrelic/logging/logback/NewRelicLogbackHttpTests.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2019 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.newrelic.logging.logback;
+
+import static com.newrelic.logging.logback.NewRelicHttpAppender.PLUGIN_TYPE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ThrowableProxy;
+import com.newrelic.api.agent.Agent;
+
+import com.newrelic.api.agent.Config;
+import com.newrelic.logging.core.ElementName;
+import com.newrelic.logging.forwarder.LogForwarderConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import com.newrelic.telemetry.logs.Log;
+
+import com.newrelic.logging.forwarder.LogForwarder;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.LoggingEvent;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class NewRelicLogbackHttpTests {
+    private static final long TIMESTAMP = 1234L;
+    private static final Throwable CAUSE = new Throwable("a_throwable_cause_message");
+    private static final Throwable THROWABLE = new Throwable("a_throwable_message", CAUSE);
+
+    private NewRelicHttpAppender appender;
+    private LoggingEvent event;
+    private final List<Log> logs = new ArrayList<>();
+    private LogForwarder forwarder;
+
+    @Test
+    @Timeout(3)
+    void shouldWorkCorrectly() throws Throwable {
+        givenTheStartedAppender();
+        givenALoggingEvent();
+        whenTheEventIsAppended();
+        thenLogForwarderIsCalled();
+        thenLogAttributesAreSetCorrectly();
+    }
+
+    @Test
+    @Timeout(3)
+    void shouldConfigureTheForwarderCorrectly() throws Throwable {
+        givenTheStartedAppenderWithCustomConfigurationParameters();
+        thenLogForwarderIsCreatedWithCustomConfiguration();
+    }
+
+    private void givenTheStartedAppenderWithCustomConfigurationParameters() {
+        givenTheAppender();
+        appender.setEndpoint("https://a-custom-endpoint/log/v1");
+        appender.setLicense("a-custom-license");
+        appender.setMaxQueuedLogs(1_000);
+        appender.setMaxLogsPerBatch(100);
+        appender.setMaxTerminationTimeSeconds(600);
+        appender.start();
+    }
+
+    private void thenLogForwarderIsCreatedWithCustomConfiguration() {
+        ArgumentCaptor<LogForwarderConfiguration> capturedConfiguration = ArgumentCaptor.forClass(LogForwarderConfiguration.class);
+        Mockito.verify(appender).createForwarder(eq(PLUGIN_TYPE), capturedConfiguration.capture());
+        assertEquals("https://a-custom-endpoint/log/v1", capturedConfiguration.getValue().getEndpoint());
+        assertEquals("a-custom-license", capturedConfiguration.getValue().getLicense());
+        assertEquals(1_000, capturedConfiguration.getValue().getMaxQueuedLogs());
+        assertEquals(100, capturedConfiguration.getValue().getMaxLogsPerBatch());
+        assertEquals(600, capturedConfiguration.getValue().getMaxTerminationTimeSeconds());
+        // TODO: Add other configurations
+    }
+
+    private void givenTheStartedAppender() {
+        givenTheAppender();
+        appender.start();
+    }
+
+    private void givenTheAppender() {
+        appender = Mockito.spy(new NewRelicHttpAppender());
+        forwarder = Mockito.mock(LogForwarder.class);
+        Mockito.doReturn(forwarder).when(appender).createForwarder(eq(PLUGIN_TYPE), any());
+        LoggerContext context = new LoggerContext();
+        appender.setContext(context);
+    }
+
+    private void givenALoggingEvent() {
+        event = new LoggingEvent();
+        event.setTimeStamp(TIMESTAMP);
+        event.setThreadName("a-thread-name");
+        event.setMessage("a-test-error-message");
+        event.setLevel(Level.ERROR);
+        event.setLoggerName("a-logger-name");
+        Map<String, String> mdcMap = new HashMap<>();
+        mdcMap.put("some.mdc.key", "an-mdc-value");
+        event.setMDCPropertyMap(mdcMap);
+        event.setThrowableProxy(new ThrowableProxy(THROWABLE));
+    }
+
+    private void whenTheEventIsAppended() {
+        appender.doAppend(event);
+    }
+
+    private void thenLogForwarderIsCalled() {
+        ArgumentCaptor<Log> capturedLog = ArgumentCaptor.forClass(Log.class);
+        Mockito.verify(forwarder).append(capturedLog.capture());
+        logs.add(capturedLog.getValue());
+    }
+
+    private void thenLogAttributesAreSetCorrectly() throws Throwable {
+        assertEquals(1, logs.size());
+        assertEquals(TIMESTAMP, logs.get(0).getTimestamp());
+        assertEquals("ERROR", logs.get(0).getLevel());
+        assertEquals("a-test-error-message", logs.get(0).getMessage());
+        assertEquals("a-thread-name", logs.get(0).getAttributes().asMap().get(ElementName.THREAD_NAME));
+        assertEquals("a-logger-name", logs.get(0).getAttributes().asMap().get(ElementName.LOGGER_NAME));
+        assertEquals("an-agent-value", logs.get(0).getAttributes().asMap().get("some.agent.key"));
+        assertEquals("an-mdc-value", logs.get(0).getAttributes().asMap().get("some.mdc.key"));
+        assertEquals(THROWABLE, logs.get(0).getThrowable());
+        assertEquals(CAUSE, logs.get(0).getThrowable().getCause());
+    }
+
+    private void mockAgent() {
+        // Agent mock
+        Config config = Mockito.mock(Config.class);
+        Agent agent = Mockito.mock(Agent.class);
+        Mockito.when(config.getValue(eq("license_key"))).thenReturn("a-sample-license-key");
+        Mockito.when(agent.getConfig()).thenReturn(config);
+
+        // Agent mocked attributes
+        Map<String, String> attributesMap = new HashMap<>();
+        attributesMap.put("some.agent.key", "an-agent-value");
+        Mockito.when(agent.getLinkingMetadata()).thenReturn(attributesMap);
+
+        // Replace agent supplier
+        NewRelicHttpAppender.agentSupplier = () -> agent;
+    }
+
+    @BeforeEach
+    void init() {
+        mockAgent();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        logs.clear();
+        appender.stop();
+    }
+}

--- a/logback11/build.gradle.kts
+++ b/logback11/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-core:2.11.1")
     implementation("ch.qos.logback:logback-core:1.1.1")
     implementation("ch.qos.logback:logback-classic:1.1.1")
-    implementation("com.newrelic.agent.java:newrelic-api:7.4.3")
+    implementation("com.newrelic.agent.java:newrelic-api:7.6.0")
     includeInJar(project(":core"))
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")

--- a/performance/log4j2-perf/build.gradle.kts
+++ b/performance/log4j2-perf/build.gradle.kts
@@ -13,10 +13,10 @@ repositories {
 dependencies {
     implementation(project(":log4j2"))
 
-    implementation("org.apache.logging.log4j:log4j-api:2.16.0")
+    implementation("org.apache.logging.log4j:log4j-api:2.17.2")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.11.1")
     implementation("com.lmax:disruptor:3.4.2")
-    implementation("com.newrelic.agent.java:newrelic-api:7.4.3")
+    implementation("com.newrelic.agent.java:newrelic-api:7.6.0")
 }
 
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,7 @@ include 'jul'
 include 'dropwizard'
 include 'core'
 include 'core-test'
+include 'forwarder'
 
 include 'examples:log4j1-app'
 include 'examples:log4j2-app'
@@ -16,3 +17,4 @@ include 'examples:jul-app'
 include 'examples:dropwizard-app'
 
 include 'performance:log4j2-perf'
+


### PR DESCRIPTION
Hi here, from logging team 👋 

Now, if customers want to forward their app logs to NR they need to configure their application to save logs in a file and setup fluent-bit. With this new feature we provide an HTTP log forwarder within the `logback` extension that will fit for some use cases where install external log forwarders is not an option.

### Steps to configure http log forwarder
Configure the `NewRelicHttpAppender` as follows:

```xml
    <appender name="HTTP" class="com.newrelic.logging.logback.NewRelicHttpAppender">
        <!-- Those are the default configuration values -->
        <!-- <endpoint>https://log-api.newrelic.com/log/v1</endpoint> -->
        <!-- <license></license> -->
        <!-- <maxQueuedLogs>100000</maxQueuedLogs> -->
        <!-- <maxLogsPerBatch>10000</maxLogsPerBatch> -->
        <!-- <maxTerminationTimeSeconds>10</maxTerminationTimeSeconds> -->
        <!-- <flushIntervalSeconds>1</flushIntervalSeconds> -->
        <!-- <maxScheduledLogsToBeAppended>1000</maxScheduledLogsToBeAppended> -->
    </appender>
```

###### License will be picked up from the java-agent if installed, but can be override if it is needed.
###### Endpoint need to be set for other cases different to NewRelic US endpoint, which is the default.


### Resources
* [MMF documentation](https://newrelic.atlassian.net/wiki/spaces/TDP/pages/2342617118/MMF+-+APM+Java+Agent+to+record+Logging+metrics+Logback+1.2)
* Performance test reported [here](https://source.datanerd.us/logging/java-log-extensions/pull/2)