### PR TITLE
feat: added logback marker to JSON layout if present

### DIFF
--- a/core/src/main/java/com/newrelic/logging/core/ElementName.java
+++ b/core/src/main/java/com/newrelic/logging/core/ElementName.java
@@ -6,6 +6,7 @@ package com.newrelic.logging.core;
 
 public class ElementName {
     public static final String MESSAGE = "message";
+    public static final String MARKER = "marker";
     public static final String TIMESTAMP = "timestamp";
     public static final String THREAD_NAME = "thread.name";
     public static final String LOG_LEVEL = "log.level";

--- a/logback/src/main/java/com/newrelic/logging/logback/NewRelicJsonLayout.java
+++ b/logback/src/main/java/com/newrelic/logging/logback/NewRelicJsonLayout.java
@@ -69,6 +69,10 @@ public class NewRelicJsonLayout extends LayoutBase<ILoggingEvent> {
             }
         }
 
+        if (event.getMarker() != null) {
+            generator.writeStringField(ElementName.MARKER, event.getMarker().getName());
+        }
+
         Object[] customArgumentArray = event.getArgumentArray();
         if (customArgumentArray != null) {
             for (Object oneCustomArgumentObject : customArgumentArray) {

--- a/logback11/src/main/java/com/newrelic/logging/logback11/NewRelicJsonLayout.java
+++ b/logback11/src/main/java/com/newrelic/logging/logback11/NewRelicJsonLayout.java
@@ -54,6 +54,10 @@ public class NewRelicJsonLayout extends LayoutBase<ILoggingEvent> {
             }
         }
 
+        if (event.getMarker() != null) {
+            generator.writeStringField(ElementName.MARKER, event.getMarker().getName());
+        }
+
         generator.writeEndObject();
     }
 }


### PR DESCRIPTION
While Logback markers are typically used for triggering and filtering at the application level, they can also be useful in New Relic. In particular, our use case involves triggering alerts when certain markers are present. This pull request simply adds the marker to the JSON data if present.