### PR TITLE
Update to TelemetrySDK 0.13.2 to address CVE-2022-25647

### DIFF
--- a/forwarder/build.gradle.kts
+++ b/forwarder/build.gradle.kts
@@ -11,8 +11,8 @@ repositories {
 
 dependencies {
     implementation("com.newrelic.agent.java:newrelic-api:7.6.0")
-    implementation("com.newrelic.telemetry:telemetry-core:0.13.1")
-    implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.13.1")
+    implementation("com.newrelic.telemetry:telemetry-core:0.13.2")
+    implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.13.2")
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
     testImplementation("org.mockito:mockito-core:3.4.4")

--- a/logback/build.gradle.kts
+++ b/logback/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-core:2.11.1")
     implementation("ch.qos.logback:logback-core:1.2.0")
     implementation("ch.qos.logback:logback-classic:1.2.0")
-    implementation("com.newrelic.telemetry:telemetry-core:0.13.1")
+    implementation("com.newrelic.telemetry:telemetry-core:0.13.2")
     implementation("com.newrelic.agent.java:newrelic-api:7.6.0")
 
     includeInJar(project(":forwarder"))


### PR DESCRIPTION
Fixes https://github.com/newrelic/java-log-extensions/issues/58