### PR TITLE
Prevent includeJar in logback adding transitives in forwarder in a fatjar style

### DIFF
--- a/forwarder/build.gradle.kts
+++ b/forwarder/build.gradle.kts
@@ -9,10 +9,15 @@ repositories {
     mavenCentral()
 }
 
+// Prevent dependencies in this subproject from getting fat-jar-ed into projects using includeInJar
+val compileAndTestOnly: Configuration by configurations.creating
+configurations["compileOnly"].extendsFrom(compileAndTestOnly)
+configurations["testImplementation"].extendsFrom(compileAndTestOnly)
+
 dependencies {
-    implementation("com.newrelic.agent.java:newrelic-api:7.6.0")
-    implementation("com.newrelic.telemetry:telemetry-core:0.13.2")
-    implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.13.2")
+    compileAndTestOnly("com.newrelic.agent.java:newrelic-api:7.6.0")
+    compileAndTestOnly("com.newrelic.telemetry:telemetry-core:0.13.2")
+    compileAndTestOnly("com.newrelic.telemetry:telemetry-http-okhttp:0.13.2")
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
     testImplementation("org.mockito:mockito-core:3.4.4")

--- a/logback/build.gradle.kts
+++ b/logback/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation("ch.qos.logback:logback-core:1.2.0")
     implementation("ch.qos.logback:logback-classic:1.2.0")
     implementation("com.newrelic.telemetry:telemetry-core:0.13.2")
+    implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.13.2")
     implementation("com.newrelic.agent.java:newrelic-api:7.6.0")
 
     includeInJar(project(":forwarder"))


### PR DESCRIPTION
The includeJar script in logback is using a flatMap of the forwarder project.  This includes both source and transitives which means that the okhttp client kotlin and slf4j are being included, unshaded in the logback jar.

By making these dependencies compile/test only in forwarder this is prevented.  There may be better ways of achieving this though!