### PR TITLE
Fix mdc logback

### DIFF
--- a/examples/logback-app/build.gradle.kts
+++ b/examples/logback-app/build.gradle.kts
@@ -12,8 +12,8 @@ repositories {
 
 dependencies {
     implementation(project(":logback"))
-    implementation("ch.qos.logback:logback-core:1.4.11")
-    implementation("ch.qos.logback:logback-classic:1.4.11")
+    implementation("ch.qos.logback:logback-core:1.3.9")
+    implementation("ch.qos.logback:logback-classic:1.3.9")
     implementation("com.fasterxml.jackson.core:jackson-core:2.11.1")
 
     implementation("com.newrelic.agent.java:newrelic-api:8.6.0")
@@ -21,8 +21,8 @@ dependencies {
 
 
 configure<JavaPluginConvention> {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 application {

--- a/examples/logback-app/build.gradle.kts
+++ b/examples/logback-app/build.gradle.kts
@@ -12,17 +12,17 @@ repositories {
 
 dependencies {
     implementation(project(":logback"))
-    implementation("ch.qos.logback:logback-core:1.2.3")
-    implementation("ch.qos.logback:logback-classic:1.2.3")
+    implementation("ch.qos.logback:logback-core:1.4.11")
+    implementation("ch.qos.logback:logback-classic:1.4.11")
     implementation("com.fasterxml.jackson.core:jackson-core:2.11.1")
 
-    implementation("com.newrelic.agent.java:newrelic-api:7.6.0")
+    implementation("com.newrelic.agent.java:newrelic-api:8.6.0")
 }
 
 
 configure<JavaPluginConvention> {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 application {

--- a/logback/build.gradle.kts
+++ b/logback/build.gradle.kts
@@ -27,8 +27,8 @@ dependencies {
 
     includeInJar(project(":core"))
 
-    testImplementation("ch.qos.logback:logback-core:1.4.11");
-    testImplementation("ch.qos.logback:logback-classic:1.4.11");
+    testImplementation("ch.qos.logback:logback-core:1.3.9");
+    testImplementation("ch.qos.logback:logback-classic:1.3.9");
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
     testImplementation("com.google.guava:guava:30.0-jre")
     testImplementation("org.mockito:mockito-core:3.4.4")

--- a/logback/build.gradle.kts
+++ b/logback/build.gradle.kts
@@ -27,6 +27,8 @@ dependencies {
 
     includeInJar(project(":core"))
 
+    testImplementation("ch.qos.logback:logback-core:1.4.11");
+    testImplementation("ch.qos.logback:logback-classic:1.4.11");
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
     testImplementation("com.google.guava:guava:30.0-jre")
     testImplementation("org.mockito:mockito-core:3.4.4")


### PR DESCRIPTION
Fixes #76 

Fixes reported issue where MDC context data was lost when running the NR Logback extension with Logback versions 1.4.8 and up. 

Updates the extension, bumps the version for the logback tests and logback example app to 1.3.9. 