### PR TITLE
Remove commons-lang classes from final logging extension jars

### DIFF
--- a/dropwizard/build.gradle.kts
+++ b/dropwizard/build.gradle.kts
@@ -17,6 +17,7 @@ repositories {
 }
 
 val includeInJar: Configuration by configurations.creating
+includeInJar.exclude(group = "org.apache.commons")
 configurations["compileOnly"].extendsFrom(includeInJar)
 
 dependencies {

--- a/jul/build.gradle.kts
+++ b/jul/build.gradle.kts
@@ -17,6 +17,7 @@ repositories {
 }
 
 val includeInJar: Configuration by configurations.creating
+includeInJar.exclude(group = "org.apache.commons")
 configurations["compileOnly"].extendsFrom(includeInJar)
 
 dependencies {

--- a/log4j1/build.gradle.kts
+++ b/log4j1/build.gradle.kts
@@ -17,6 +17,7 @@ repositories {
 }
 
 val includeInJar: Configuration by configurations.creating
+includeInJar.exclude(group = "org.apache.commons")
 configurations["compileOnly"].extendsFrom(includeInJar)
 
 dependencies {

--- a/log4j2/build.gradle.kts
+++ b/log4j2/build.gradle.kts
@@ -18,6 +18,7 @@ repositories {
 }
 
 val includeInJar: Configuration by configurations.creating
+includeInJar.exclude(group = "org.apache.commons")
 configurations["compileOnly"].extendsFrom(includeInJar)
 
 dependencies {

--- a/logback/build.gradle.kts
+++ b/logback/build.gradle.kts
@@ -17,6 +17,7 @@ repositories {
 }
 
 val includeInJar: Configuration by configurations.creating
+includeInJar.exclude(group = "org.apache.commons")
 configurations["compileOnly"].extendsFrom(includeInJar)
 
 dependencies {

--- a/logback11/build.gradle.kts
+++ b/logback11/build.gradle.kts
@@ -17,6 +17,7 @@ repositories {
 }
 
 val includeInJar: Configuration by configurations.creating
+includeInJar.exclude(group = "org.apache.commons")
 configurations["compileOnly"].extendsFrom(includeInJar)
 
 dependencies {


### PR DESCRIPTION
Resolves #102 

Update the extension project build files to exclude `commons-lang` classes from the final jars.